### PR TITLE
fix: KokoroTTS の try! クラッシュリスクとメインスレッドブロッキング解消 (#53)

### DIFF
--- a/iOS/LocalPackages/KokoroSwift/Sources/KokoroSwift/TTSEngine/KokoroTTS.swift
+++ b/iOS/LocalPackages/KokoroSwift/Sources/KokoroSwift/TTSEngine/KokoroTTS.swift
@@ -63,9 +63,11 @@ public final class KokoroTTS {
   /// - Parameters:
   ///   - modelPath: URL to the directory containing model weights
   ///   - g2p: Grapheme-to-phoneme processor type (default: Misaki)
-  public init(modelPath: URL, g2p: G2P = .misaki) {
+  /// - Throws: An error if model weights cannot be loaded from `modelPath`
+  ///           (e.g. corrupted or incomplete model file).
+  public init(modelPath: URL, g2p: G2P = .misaki) throws {
     // Load and sanitize model weights
-    let sanitizedWeights = WeightLoader.loadWeights(modelPath: modelPath)
+    let sanitizedWeights = try WeightLoader.loadWeights(modelPath: modelPath)
     let config = KokoroConfig.loadConfig()
     
     // Initialize BERT model for phoneme encoding

--- a/iOS/LocalPackages/KokoroSwift/Sources/KokoroSwift/TTSEngine/WeightLoader.swift
+++ b/iOS/LocalPackages/KokoroSwift/Sources/KokoroSwift/TTSEngine/WeightLoader.swift
@@ -30,10 +30,12 @@ final class WeightLoader {
   /// - **Decoder weights**: Transposes noise convolution weights and handles weight_v conditionally
   /// - Parameter modelPath: URL to the directory containing model weight files
   /// - Returns: Dictionary mapping weight names to their processed MLXArray tensors
-  /// - Note: Uses forced try (try!) as weight loading is critical and should fail fast if unsuccessful
-  static func loadWeights(modelPath: URL) -> [String: MLXArray] {
+  /// - Throws: An error if the weight file cannot be loaded (e.g. corrupted, incomplete
+  ///           download, or insufficient disk space). Callers are expected to surface a
+  ///           user-facing error rather than crashing.
+  static func loadWeights(modelPath: URL) throws -> [String: MLXArray] {
     // Load raw weights from disk
-    let weights = try! MLX.loadArrays(url: modelPath)
+    let weights = try MLX.loadArrays(url: modelPath)
     var sanitizedWeights: [String: MLXArray] = [:]
 
     // Process each weight based on its component prefix

--- a/iOS/VoiceYourText/Features/KokoroTTS/KokoroTTSClient.swift
+++ b/iOS/VoiceYourText/Features/KokoroTTS/KokoroTTSClient.swift
@@ -114,17 +114,24 @@ actor KokoroEngine {
     private var ttsJapanese: KokoroTTS?
     private var voices: [String: MLXArray]?
 
+    // 同一言語の初回ロードが並行して走っても二重ロード（≒600MB×2）にならないよう
+    // 進行中のロード Task をキャッシュして共有する。
+    private var englishLoadTask: Task<KokoroTTS, Error>?
+    private var japaneseLoadTask: Task<KokoroTTS, Error>?
+
     func synthesize(text: String, voice: KokoroVoice, speed: Float) async throws -> Data {
         guard KokoroModelManager.checkDownloaded(),
               let modelURL  = await KokoroModelManager.shared.modelFileURL(),
               let voicesURL = await KokoroModelManager.shared.voicesFileURL()
         else { throw KokoroError.modelNotDownloaded }
 
-        // 初回のみロード（重い処理）
+        // 初回のみロード（重い処理）。約600MBのモデル読み込み＋複数NNの構築は
+        // メインスレッド・アクターのエグゼキュータを塞がないよう detached Task で実行する。
+        let tts: KokoroTTS
         if voice.isJapanese {
-            if ttsJapanese == nil { ttsJapanese = KokoroTTS(modelPath: modelURL, g2p: .japanese) }
+            tts = try await loadJapaneseTTS(modelURL: modelURL)
         } else {
-            if ttsEnglish == nil { ttsEnglish = KokoroTTS(modelPath: modelURL, g2p: .misaki) }
+            tts = try await loadEnglishTTS(modelURL: modelURL)
         }
         if voices == nil {
             voices = try loadVoicesNPZ(url: voicesURL)
@@ -135,7 +142,6 @@ actor KokoroEngine {
             throw KokoroError.synthesisFailure("Voice '\(voice.rawValue)' not found in voices.npz")
         }
 
-        let tts = voice.isJapanese ? ttsJapanese! : ttsEnglish!
         let language: Language = voice.isJapanese ? .ja : .enUS
 
         let (samples, _) = try tts.generateAudio(
@@ -146,6 +152,50 @@ actor KokoroEngine {
         )
 
         return try pcmToWAV(samples: samples, sampleRate: 24000)
+    }
+
+    // MARK: - モデルロード（off-main / 二重ロード防止）
+
+    private func loadEnglishTTS(modelURL: URL) async throws -> KokoroTTS {
+        if let tts = ttsEnglish {
+            return tts
+        }
+        if let task = englishLoadTask {
+            return try await task.value
+        }
+        let task = Task.detached(priority: .userInitiated) {
+            try KokoroTTS(modelPath: modelURL, g2p: .misaki)
+        }
+        englishLoadTask = task
+        defer { englishLoadTask = nil }
+        do {
+            let tts = try await task.value
+            ttsEnglish = tts
+            return tts
+        } catch {
+            throw KokoroError.synthesisFailure("モデルの読み込みに失敗しました: \(error.localizedDescription)")
+        }
+    }
+
+    private func loadJapaneseTTS(modelURL: URL) async throws -> KokoroTTS {
+        if let tts = ttsJapanese {
+            return tts
+        }
+        if let task = japaneseLoadTask {
+            return try await task.value
+        }
+        let task = Task.detached(priority: .userInitiated) {
+            try KokoroTTS(modelPath: modelURL, g2p: .japanese)
+        }
+        japaneseLoadTask = task
+        defer { japaneseLoadTask = nil }
+        do {
+            let tts = try await task.value
+            ttsJapanese = tts
+            return tts
+        } catch {
+            throw KokoroError.synthesisFailure("モデルの読み込みに失敗しました: \(error.localizedDescription)")
+        }
     }
 
     // NPZ（ZIP of NPY files）を読み込み MLXArray の辞書を返す


### PR DESCRIPTION
## 対応issue
Closes #53

## 変更内容
KokoroTTS統合(v0.29.0)で検出された高優先度のクラッシュ／パフォーマンスリスク2件に対応。

### A: `try!` によるランタイムクラッシュの除去
- `WeightLoader.loadWeights(modelPath:)` を `try!` → `throws` に変更。約600MBのモデル読み込みが
  破損・不完全DL・ディスク容量不足で失敗してもクラッシュしなくなった。
- `KokoroTTS.init(modelPath:g2p:)` を `throws` に変更し、エラーを呼び出し元へ伝播。
- 呼び出し元 (`KokoroEngine`) で `KokoroError.synthesisFailure` にラップし、ユーザー向けエラーとして扱う。

### B: モデルロードの off-main 化（UIフリーズ防止）
- 重い初回ロード（BERT/LSTM/Decoder 等の構築）を `Task.detached(priority: .userInitiated)` に移し、
  メインスレッド／アクターのエグゼキュータをブロックしないようにした。
- 同一言語の初回ロードが並行して走っても二重ロード（≒600MB×2）にならないよう、進行中の
  ロード Task をキャッシュして共有する仕組みを追加。

変更ファイル:
- `iOS/LocalPackages/KokoroSwift/Sources/KokoroSwift/TTSEngine/WeightLoader.swift`
- `iOS/LocalPackages/KokoroSwift/Sources/KokoroSwift/TTSEngine/KokoroTTS.swift`
- `iOS/VoiceYourText/Features/KokoroTTS/KokoroTTSClient.swift`

## ハーネス検証結果
- ビルド: ✅ KokoroSwift パッケージを macOS arm64 で `swift build` → `Build complete!`（WeightLoader / KokoroTTS / KokoroTTSClient の変更箇所がコンパイル・リンク成功）
  - ※ アプリ全体ビルドは MLX が iOS シミュレータでリンク不可のため未実施（実機/Designed for iPad が必要）。`KokoroTTSClient.swift` は app ターゲット所属のため単体ビルド不可だが、変更は throwing API への素直な伝播のみ。
  - ※ 検証のため Package.swift の macOS を一時的に v15 にして build したが、コミットには含めていない（v14 のまま）。
- テスト: なし（KokoroSwift にテストターゲットは存在せず、app テストは上記 MLX シミュレータ制約で実行不可）
- Lint: ✅ SwiftLint で本変更が新規違反を導入していないことを確認（追加した4件の `conditional_returns_on_newline` は修正済み）。`KokoroTTS.swift` に既存の error 級違反が残るが、本変更の対象外かつ `.swiftlint.yml` の `included` が未設定で LocalPackages は通常 lint 対象外。

## 人間に確認してほしい点
- `Task.detached` から返る `KokoroTTS`(非Sendable)を actor 内へ受け渡す箇所について、Swift 6 strict concurrency 下で警告/エラーが出ないか実機ビルドで最終確認をお願いします（macOS swift build では通過）。
- 実機での初回読み上げ時に UI フリーズが解消され、モデル破損時にクラッシュせずエラー表示されることの実機確認。

---
*このPRは resolve-issues スキルにより作成されました*